### PR TITLE
fix: resolve React Fast Refresh ESLint error by separating context exports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Routes, Route, Link} from 'react-router-dom';
-import { CryptoProvider, useCrypto } from './context/CryptoContext';
+import { CryptoProvider } from './context/CryptoProvider';
+import { useCrypto } from './hooks/useCrypto';
 import Home from './pages/Home';
 import Analysis from './pages/Analysis';
 

--- a/src/components/MarketChart.jsx
+++ b/src/components/MarketChart.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
-import { useCrypto } from '../context/CryptoContext';
+import { useCrypto } from '../hooks/useCrypto';
 
 const MarketChart = () => {
     const { coins, currency } = useCrypto();

--- a/src/context/CryptoContext.js
+++ b/src/context/CryptoContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const CryptoContext = createContext();

--- a/src/context/CryptoProvider.jsx
+++ b/src/context/CryptoProvider.jsx
@@ -1,6 +1,5 @@
-import { createContext, useState, useContext } from 'react';
-
-const CryptoContext = createContext();
+import { useState } from 'react';
+import { CryptoContext } from './CryptoContext';
 
 export const CryptoProvider = ({ children }) => {
     const [coins, setCoins] = useState([]);
@@ -12,5 +11,3 @@ export const CryptoProvider = ({ children }) => {
         </CryptoContext.Provider>
     );
 };
-
-export const useCrypto = () => useContext(CryptoContext);

--- a/src/hooks/useCrypto.js
+++ b/src/hooks/useCrypto.js
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { CryptoContext } from '../context/CryptoContext.js';
+
+export const useCrypto = () => useContext(CryptoContext);

--- a/src/hooks/useFetchCrypto.js
+++ b/src/hooks/useFetchCrypto.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useCrypto } from '../context/CryptoContext';
+import { useCrypto } from './useCrypto';
 
 // 1. The "Memory Bank" sits outside the hook so it survives page changes
 const apiCache = {};

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from 'react';
 import { useFetchCrypto } from '../hooks/useFetchCrypto';
-import { useCrypto } from '../context/CryptoContext';
+import { useCrypto } from '../hooks/useCrypto';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 
 const Home = () => {


### PR DESCRIPTION
## Summary
This PR fixes a frontend bug where ESLint was failing due to the `react-refresh/only-export-components` rule violation.

## Problem
The original `CryptoContext.jsx` file exported both the Context object and the `useCrypto` hook alongside the `CryptoProvider` component. This violates React Fast Refresh rules, which require files to only export React components for Hot Module Replacement (HMR) to work properly.

## Solution
Restructured the context module following React best practices:

1. **`src/context/CryptoContext.js`** - Contains only the Context definition
2. **`src/context/CryptoProvider.jsx`** - Contains only the Provider component  
3. **`src/hooks/useCrypto.js`** - Contains the custom hook for consuming context

Updated all imports across the codebase to use the new file structure.

## Changes
- `src/context/CryptoContext.jsx` → Split into `CryptoContext.js` + `CryptoProvider.jsx`
- New `src/hooks/useCrypto.js` for the context consumer hook
- Updated imports in: `App.jsx`, `Home.jsx`, `MarketChart.jsx`, `useFetchCrypto.js`

## Testing
- ✅ ESLint passes with no errors
- ✅ Build completes successfully
- ✅ All components work as expected

Closes #1